### PR TITLE
PR-21 판매자 검색을 통한 식자재 등록 기능

### DIFF
--- a/android/app/src/main/java/com/pbl/grandmarket_android/data/local/UserSession.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/data/local/UserSession.kt
@@ -17,7 +17,7 @@ object UserSession {
     fun getRole(context: Context): UserRole {
         val roleValue = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
             .getString(KEY_USER_ROLE, null)
-        return UserRole.Companion.from(roleValue)
+        return UserRole.from(roleValue)
     }
 
     fun clear(context: Context) {

--- a/android/app/src/main/java/com/pbl/grandmarket_android/data/model/FoodEntity.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/data/model/FoodEntity.kt
@@ -1,0 +1,12 @@
+package com.pbl.grandmarket_android.data.model
+
+data class FoodEntity (
+    val kakaoId: String = "",   //카카오 고유 식별 id
+    val sellerName: String = "",    //판매자 카카오 닉네임
+    val foodName: String = "",  //식자재 이름
+    val price: Long = 0L,   //판매자가 지정한 가격
+    val marketPrice: Long = 0L, //해당 식자재 평균 시세
+    val category: String = "",  //식자재 카테고리
+    val status: String = "판매중", //판매 상황
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/android/app/src/main/java/com/pbl/grandmarket_android/data/repository/FoodRepository.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/data/repository/FoodRepository.kt
@@ -1,0 +1,68 @@
+package com.pbl.grandmarket_android.data.repository
+
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import com.kakao.sdk.user.UserApiClient
+import com.pbl.grandmarket_android.data.model.FoodEntity
+
+class FoodRepository {
+    private val db = FirebaseFirestore.getInstance()
+
+    fun foodAddWithValidation(
+        foodName: String,
+        price: Long,
+        marketPrice: Long,
+        onResult: (isSuccess: Boolean, message: String?) -> Unit
+    ) {
+        UserApiClient.instance.me { user, error ->
+            if (error != null || user == null) {
+                return@me
+            }
+
+            val kakaoId = user.id.toString()
+            val nickname = user.kakaoAccount?.profile?.nickname ?: "익명 판매자"
+
+            // 점포 등록된 상태인지 확인
+            db.collection("storeLocation").document(kakaoId).get()
+                .addOnSuccessListener { document ->
+                    if (document.exists()) {
+                        saveFoodToFirebase(kakaoId, nickname, foodName, price, marketPrice, onResult)
+                    } else {
+                        // TODO: "점포를 먼저 등록해주세요" 팝업이나 알림 띄우기
+                        onResult(false, "점포를 먼저 등록해주세요")
+                    }
+                }
+                .addOnFailureListener { error ->
+                    Log.d("FoodRepository", "점포 확인 에러 (네트워크)")
+                    onResult(false,"네트워크 오류 발생")
+                }
+        }
+    }
+
+    private fun saveFoodToFirebase(
+        kakaoId: String,
+        sellerName: String,
+        foodName: String,
+        price: Long,
+        marketPrice: Long,
+        onResult: (Boolean, String?) -> Unit
+    ) {
+        val foodData = FoodEntity(
+            kakaoId = kakaoId,
+            sellerName = sellerName,
+            foodName = foodName,
+            price = price,
+            marketPrice = marketPrice
+        )
+
+        db.collection("foodList").add(foodData)
+            .addOnSuccessListener { documentReference ->
+                Log.d("FoodRepository", "상품 등록 성공: ${documentReference.id}")
+                onResult(true, "${foodName} 성공적으로 등록")
+            }
+            .addOnFailureListener { error ->
+                Log.d("FoodRepository", "상품 등록 실패: ", error)
+                onResult(false, "${foodName} 등록 실패!!")
+            }
+    }
+}

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/adapter/SalesAdapter.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/adapter/SalesAdapter.kt
@@ -45,7 +45,7 @@ class SaleItemDiffCallback : DiffUtil.ItemCallback<SaleItem>() {
 class SalesAdapter(
     private val onItemClick: (SaleItem) -> Unit,
     private val onMoreClick: (SaleItem) -> Unit
-) : androidx.recyclerview.widget.ListAdapter<SaleItem, SalesAdapter.SaleViewHolder>(SaleItemDiffCallback()) {
+) : ListAdapter<SaleItem, SalesAdapter.SaleViewHolder>(SaleItemDiffCallback()) {
 
     inner class SaleViewHolder(
         private val binding: ItemSaleBinding
@@ -64,12 +64,12 @@ class SalesAdapter(
                 ProductCategory.VEGETABLE -> {
                     binding.tvCategory.text = "채소"
                     binding.tvCategory.setTextColor(Color.parseColor("#C05E00"))
-                    binding.tvCategory.setBackgroundResource(_root_ide_package_.com.pbl.grandmarket_android.R.drawable.bg_item_list_veg)
+                    binding.tvCategory.setBackgroundResource(com.pbl.grandmarket_android.R.drawable.bg_item_list_veg)
                 }
                 ProductCategory.MEAT -> {
                     binding.tvCategory.text = "육류"
                     binding.tvCategory.setTextColor(Color.parseColor("#B71C1C"))
-                    binding.tvCategory.setBackgroundResource(_root_ide_package_.com.pbl.grandmarket_android.R.drawable.bg_item_list_meat)
+                    binding.tvCategory.setBackgroundResource(com.pbl.grandmarket_android.R.drawable.bg_item_list_meat)
                 }
             }
 

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/home/HomeFragment.kt
@@ -11,10 +11,13 @@ import com.kakao.sdk.user.UserApiClient
 import com.pbl.grandmarket_android.R
 import com.pbl.grandmarket_android.data.model.UserRole
 import com.pbl.grandmarket_android.data.local.UserSession
+import com.pbl.grandmarket_android.ui.item_list.RegisterItemBottomSheet
 
 class HomeFragment : Fragment() {
 
     private var introMessageText: TextView? = null
+    private var btnSearchRegister: View? = null
+    private var homeSearchBar: View? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -31,10 +34,13 @@ class HomeFragment : Fragment() {
 
         val view = inflater.inflate(layoutRes, container, false)
 
-        // seller / buyer 레이아웃 모두 introMessageText ID 동일해야 함
         introMessageText = view.findViewById(R.id.intro_message_text)
 
-        Log.d("HomeFragment", "role=$role, layout=$layoutRes")
+        // 판매자일 때만 버튼 초기화
+        if (role == UserRole.SELLER) {
+            btnSearchRegister = view.findViewById(R.id.btnSearchRegister)
+            homeSearchBar = view.findViewById(R.id.home_search_bar)
+        }
 
         return view
     }
@@ -42,60 +48,42 @@ class HomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         fetchKakaoProfile()
+
+        // 버튼 클릭 시 바텀시트 띄우기
+        btnSearchRegister?.setOnClickListener {
+            showRegisterBottomSheet()
+        }
+
+        homeSearchBar?.setOnClickListener {
+            showRegisterBottomSheet()
+        }
+    }
+
+    private fun showRegisterBottomSheet() {
+        // 바텀시트 열기 (등록 로직은 바텀시트 내부에서 처리됨)
+        val bottomSheet = RegisterItemBottomSheet()
+        bottomSheet.show(childFragmentManager, "RegisterItemBottomSheet")
     }
 
     private fun fetchKakaoProfile() {
         UserApiClient.instance.me { user, error ->
-
-            val currentTextView = introMessageText ?: run {
-                Log.e("HomeFragment", "introMessageText 찾기 실패")
-                return@me
-            }
+            val currentTextView = introMessageText ?: return@me
 
             if (error != null) {
-                Log.e("HomeFragment", "카카오 사용자 정보 조회 실패", error)
+                Log.e("HomeFragment", "카카오 정보 조회 실패", error)
                 return@me
             }
 
-            val account = user?.kakaoAccount
-
-            Log.d(
-                "HomeFragment",
-                "me 성공 userId=${user?.id}, profileNeedsAgreement=${account?.profileNeedsAgreement}, emailNeedsAgreement=${account?.emailNeedsAgreement}"
-            )
-
-            // 추가 동의 필요 시
-            if (account?.profileNeedsAgreement == true || account?.emailNeedsAgreement == true) {
-                Log.d("HomeFragment", "추가 동의 필요 -> loginWithNewScopes 호출")
-                requestKakaoProfileScopes()
-                return@me
-            }
-
-            val profile = account?.profile
-            val nickname = profile?.nickname ?: "사용자"
-
-            Log.d("HomeFragment", "nickname=$nickname")
-
-            currentTextView.text = currentTextView.text.toString() + nickname +"님 🖐️"
-        }
-    }
-
-    private fun requestKakaoProfileScopes() {
-        val scopes = listOf("profile_nickname", "profile_image", "account_email")
-
-        UserApiClient.instance.loginWithNewScopes(requireActivity(), scopes) { _, error ->
-            if (error != null) {
-                Log.e("HomeFragment", "카카오 추가 동의 요청 실패", error)
-                return@loginWithNewScopes
-            }
-
-            Log.d("HomeFragment", "카카오 추가 동의 성공 -> 프로필 재조회")
-            fetchKakaoProfile()
+            val nickname = user?.kakaoAccount?.profile?.nickname ?: "사용자"
+            // 기존 텍스트 뒤에 닉네임 붙이기
+            currentTextView.text = "${currentTextView.text} $nickname 님 🖐️"
         }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         introMessageText = null
+        btnSearchRegister = null
+        homeSearchBar = null
     }
 }

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/item_list/RegisterItemBottomSheet.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/item_list/RegisterItemBottomSheet.kt
@@ -1,0 +1,120 @@
+package com.pbl.grandmarket_android.ui.item_list
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import android.widget.Toast
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.pbl.grandmarket_android.R
+import com.pbl.grandmarket_android.data.remote.ApiProductService
+import com.pbl.grandmarket_android.data.repository.FoodRepository
+import kotlinx.coroutines.launch
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class RegisterItemBottomSheet : BottomSheetDialogFragment() {
+
+    private lateinit var api: ApiProductService
+    private var currentWholesalePrice = 0L // 불러온 도매가 저장용
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.bottom_sheet_item_add, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 뷰
+        val etSearchItem = view.findViewById<EditText>(R.id.etSearchItem)
+        val btnSearch = view.findViewById<Button>(R.id.btnSearch)
+        val tvWholesalePriceInfo = view.findViewById<TextView>(R.id.tvWholesalePriceInfo)
+        val etSellPrice = view.findViewById<EditText>(R.id.etSellPrice)
+        val btnMinusPrice = view.findViewById<Button>(R.id.btnMinusPrice)
+        val btnPlusPrice = view.findViewById<Button>(R.id.btnPlusPrice)
+        val btnRegisterComplete = view.findViewById<Button>(R.id.btnRegisterComplete)
+
+        // API 세팅
+        val retrofit = Retrofit.Builder()
+            .baseUrl(com.pbl.grandmarket_android.BuildConfig.SERVER_IP)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+        api = retrofit.create(ApiProductService::class.java)
+
+        // 도매가 검색 버튼 클릭
+        btnSearch.setOnClickListener {
+            val itemName = etSearchItem.text.toString()
+
+            val imm = requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.hideSoftInputFromWindow(etSearchItem.windowToken,0)
+
+            if (itemName.isNotEmpty()) {
+                tvWholesalePriceInfo.text = "조회 중..."
+                lifecycleScope.launch {
+                    try {
+                        val response = api.getAveragePrice(itemName)
+                        if (response.isSuccessful) {
+                            currentWholesalePrice = response.body() ?: 0L
+                            tvWholesalePriceInfo.text = "오늘의 $itemName 도매가: ${currentWholesalePrice}원"
+                            etSellPrice.setText(currentWholesalePrice.toString()) // 초기 가격 세팅
+                        } else {
+                            tvWholesalePriceInfo.text = "도매가 정보를 찾을 수 없습니다."
+                        }
+                    } catch (e: Exception) {
+                        tvWholesalePriceInfo.text = "네트워크 오류"
+                    }
+                }
+            }
+        }
+
+        // 가격 조절 버튼 클릭
+        btnMinusPrice.setOnClickListener {
+            var price = etSellPrice.text.toString().toLongOrNull() ?: 0L
+            if (price >= 100) price -= 100
+            etSellPrice.setText(price.toString())
+        }
+
+        btnPlusPrice.setOnClickListener {
+            var price = etSellPrice.text.toString().toLongOrNull() ?: 0L
+            price += 100
+            etSellPrice.setText(price.toString())
+        }
+
+        // 파이어베이스에 최종 등록 버튼 클릭
+        btnRegisterComplete.setOnClickListener {
+            val name = etSearchItem.text.toString()
+            val sellPrice = etSellPrice.text.toString().toLongOrNull() ?: 0L
+
+            if (name.isNotEmpty() && sellPrice > 0) {
+                // 중복 클릭 방지
+                btnRegisterComplete.isEnabled = false
+                btnRegisterComplete.text = "등록 중..."
+
+                // Repository 호출 (콜백 함수 전달)
+                val repository = FoodRepository()
+                repository.foodAddWithValidation(name, sellPrice, currentWholesalePrice) { isSuccess, message ->
+
+                    // 결과가 돌아오면 UI 복구
+                    btnRegisterComplete.isEnabled = true
+                    btnRegisterComplete.text = "내 점포에 상품 등록하기"
+
+                    // 콜백 결과(진동벨)에 따른 처리
+                    if (isSuccess) {
+                        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+                        dismiss() // 팝업창 닫기
+                    } else {
+                        Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show()
+                        // 실패 시에는 창을 닫지 않고 사용자가 다시 시도하거나 정보를 수정할 수 있게 둡니다.
+                    }
+                }
+            } else {
+                Toast.makeText(requireContext(), "상품명과 가격을 정확히 입력해주세요.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/MapBuyerFragment.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/MapBuyerFragment.kt
@@ -79,7 +79,7 @@ class MapBuyerFragment : Fragment() {
 
         startMap()
 
-        // 1. 내 위치 버튼 (우측 하단)
+        // 내 위치 버튼 (우측 하단)
         binding.fabCurrentLocation.setOnClickListener {
             checkLocationPermission()
         }
@@ -98,10 +98,10 @@ class MapBuyerFragment : Fragment() {
             }
         }
 
-        // 3. 하단 리스트 보기 팝업 버튼
+        // 하단 리스트 보기 팝업 버튼
         binding.btnShowStoreList.setOnClickListener {
             if (storeList.isEmpty()) {
-                Toast.makeText(requireContext(), "주변 반경 20km 내에 점포가 없습니다.", Toast.LENGTH_SHORT)
+                Toast.makeText(requireContext(), "주변 반경 15km 내에 점포가 없습니다.", Toast.LENGTH_SHORT)
                     .show()
             } else {
                 val bottomSheet = StoreListBottomSheetFragment(storeList)

--- a/android/app/src/main/res/layout/bottom_sheet_item_add.xml
+++ b/android/app/src/main/res/layout/bottom_sheet_item_add.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="#FFFFFF"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="32dp">
+
+    <View
+        android:layout_width="40dp"
+        android:layout_height="4dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="24dp"
+        android:background="#E5E0D5" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="식자재 검색 및 등록"
+        android:textColor="#1A1A1A"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="등록할 식자재를 검색하여 도매가를 확인해보세요."
+        android:textColor="#BBBBA8"
+        android:textSize="12sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/etSearchItem"
+            android:layout_width="0dp"
+            android:layout_height="52dp"
+            android:layout_weight="1"
+            android:background="@drawable/home_search_bar"
+            android:hint="식자재명 입력 (예: 배추)"
+            android:textColorHint="#BBBBA8"
+            android:textColor="#1A1A1A"
+            android:textSize="14sp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:maxLines="1"
+            android:inputType="text" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btnSearch"
+            android:layout_width="wrap_content"
+            android:layout_height="52dp"
+            android:layout_marginStart="10dp"
+            android:background="@drawable/home_search_bar"
+            android:backgroundTint="#E8821A"
+            android:text="검색"
+            android:textColor="#FFFFFF"
+            android:textSize="15sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/home_search_bar"
+        android:backgroundTint="#FFF5E6"
+        android:padding="14dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="📊"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/tvWholesalePriceInfo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="오늘의 도매가: 조회 대기중"
+            android:textColor="#E8821A"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="판매 가격 설정"
+        android:textColor="#1A1A1A"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btnMinusPrice"
+            android:layout_width="52dp"
+            android:layout_height="52dp"
+            android:background="@drawable/home_search_bar"
+            android:backgroundTint="#F5EFE0"
+            android:text="−"
+            android:textColor="#A8A090"
+            android:textSize="22sp"
+            android:textStyle="bold" />
+
+        <EditText
+            android:id="@+id/etSellPrice"
+            android:layout_width="0dp"
+            android:layout_height="52dp"
+            android:layout_marginHorizontal="12dp"
+            android:layout_weight="1"
+            android:background="@drawable/home_search_bar"
+            android:gravity="center"
+            android:inputType="number"
+            android:text="0"
+            android:textColor="#1A1A1A"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btnPlusPrice"
+            android:layout_width="52dp"
+            android:layout_height="52dp"
+            android:background="@drawable/home_search_bar"
+            android:backgroundTint="#FFF5E6"
+            android:text="+"
+            android:textColor="#E8821A"
+            android:textSize="22sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btnRegisterComplete"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:layout_marginTop="32dp"
+        android:background="@drawable/home_search_bar"
+        android:backgroundTint="#E8821A"
+        android:text="내 점포에 상품 등록하기"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:elevation="0dp"
+        android:stateListAnimator="@null" />
+
+</LinearLayout>


### PR DESCRIPTION
# PR-21 판매자 검색을 통한 식자재 등록 기능

> PR 제목: `PR-21 판매자 검색을 통한 식자재 등록 기능`
> 
> 브랜치명: `woneyH-feat-10`
> 
> 브랜치: `woneyH-feat-10`

---

## 🔒 Close Issue (필수)
- GitHub: Closes #37 
---


## 🔍 변경 유형

- [x] ✨ 새 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [x] ♻️ 리팩터링 (refactor)
- [ ] 🎨 스타일 / UI 개선
- [ ] 📦 의존성 업데이트
- [ ] 🔧 설정 / 빌드 변경
- [ ] 📝 문서 업데이트
- [ ] 🚀 배포 관련
- [ ] ⚡ 성능 개선
- [ ] 🔒 보안 수정

---

## 💡 작업 내용

### 무엇을 변경했나요?
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- 점포가 등록된 판매자들은 식자재 등록 기능을 이용할 수 있음.
- firebase store에 식자재 등록 기능 테스트 완료
- 식자재 등록할 때 도매가 API를 이용해 현재 식자재 시세 확인 가능



---


## ✅ 테스트

- [ ] 유닛 테스트 추가 / 수정
- [ ] 통합 테스트 확인
- [x] 로컬에서 직접 검증

<!-- 테스트 방법이나 시나리오를 설명해주세요 -->
API 36 기기

---

## 📸 스크린샷(선택)

<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요 -->

| Before | After |
|--------|-------|
|        |       |



---

## ✔️ 셀프 체크리스트

- [x] 코드 스타일 가이드를 따랐다
- [x] 불필요한 주석 / console.log를 제거했다
- [x] 하드코딩된 값이 없다
- [x] 민감 정보(API 키, 비밀번호 등)가 포함되지 않았다
- [x] PR 제목이 컨벤션에 맞게 작성되었다
