### PR TITLE
PR-26 성공적으로 객체 탐지(이미지 인식) 이후 식자재 등록 유도 기능

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,9 +9,12 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
-    <!--카메라 퍼미션 추가=-->
+    <!--카메라 퍼미션 추가-->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
+
+    <!--알람 퍼미션 추가-->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name=".ui.base.GlobalApplication"

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ai/OverlayView.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ai/OverlayView.kt
@@ -7,7 +7,7 @@ import android.graphics.Paint
 import android.graphics.RectF
 import android.util.AttributeSet
 import android.view.View
-import com.pbl.grandmarket_android.aiimport.YoloDetector
+import com.pbl.grandmarket_android.ai.YoloDetector
 
 class OverlayView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
     private val paint = Paint().apply {

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ai/YoloDetector.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ai/YoloDetector.kt
@@ -1,4 +1,4 @@
-package com.pbl.grandmarket_android.aiimport
+package com.pbl.grandmarket_android.ai
 
 import ai.onnxruntime.OnnxTensor
 import ai.onnxruntime.OrtEnvironment

--- a/android/app/src/main/java/com/pbl/grandmarket_android/data/model/StoreLocation.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/data/model/StoreLocation.kt
@@ -1,6 +1,4 @@
-package com.pbl.grandmarket_android.data.repository
-
-import com.google.firebase.Timestamp
+package com.pbl.grandmarket_android.data.model
 
 data class StoreLocation (
     val kakaoId: Long? = null,
@@ -8,5 +6,6 @@ data class StoreLocation (
     val latitude: Double? = null,
     val longitude: Double? = null,
     val address: String? = null,
+    val viewCount: Int? = null,
     val timestamp: Long = System.currentTimeMillis()
 )

--- a/android/app/src/main/java/com/pbl/grandmarket_android/data/repository/FoodRepository.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/data/repository/FoodRepository.kt
@@ -18,6 +18,30 @@ data class SellerFoodItem(
 class FoodRepository {
     private val db = FirebaseFirestore.getInstance()
 
+    // 점포 등록 여부만 확인하는 전용 함수 (AI 인식 후 등록 유도에 사용)
+    fun checkStoreExists(onResult: (isExists: Boolean, message: String?) -> Unit) {
+        UserApiClient.instance.me { user, error ->
+            if (error != null || user == null) {
+                onResult(false, "사용자 정보를 불러오지 못했습니다")
+                return@me
+            }
+
+            val kakaoId = user.id.toString()
+            db.collection("storeLocation").document(kakaoId).get()
+                .addOnSuccessListener { document ->
+                    if (document.exists()) {
+                        onResult(true, null)
+                    } else {
+                        onResult(false, "점포를 먼저 등록해주세요")
+                    }
+                }
+                .addOnFailureListener { error ->
+                    Log.d("FoodRepository", "점포 확인 에러 (네트워크)")
+                    onResult(false, "네트워크 오류 발생")
+                }
+        }
+    }
+
     fun foodAddWithValidation(
         foodName: String,
         price: Long,

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/home/HomeActivity.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/home/HomeActivity.kt
@@ -84,16 +84,24 @@ class HomeActivity : BaseActivity() {
         homeBinding.textMySellInfo.setTextColor(if (index == 1) activeColor else defaultColor)
         homeBinding.textMap.setTextColor(if (index == 2) activeColor else defaultColor)
         homeBinding.textMyInfo.setTextColor(if (index == 3) activeColor else defaultColor)
-        
+
         // 텍스트 스타일 변경 (Bold 여부)
-        homeBinding.textHome.setTypeface(null, if(index==0)
-        Typeface.BOLD else Typeface.NORMAL)
-        homeBinding.textMySellInfo.setTypeface(null, if(index==1)
-            Typeface.BOLD else Typeface.NORMAL)
-        homeBinding.textMap.setTypeface(null, if(index==2)
-            Typeface.BOLD else Typeface.NORMAL)
-        homeBinding.textMyInfo.setTypeface(null, if(index==3)
-            Typeface.BOLD else Typeface.NORMAL)
+        homeBinding.textHome.setTypeface(
+            null, if (index == 0)
+                Typeface.BOLD else Typeface.NORMAL
+        )
+        homeBinding.textMySellInfo.setTypeface(
+            null, if (index == 1)
+                Typeface.BOLD else Typeface.NORMAL
+        )
+        homeBinding.textMap.setTypeface(
+            null, if (index == 2)
+                Typeface.BOLD else Typeface.NORMAL
+        )
+        homeBinding.textMyInfo.setTypeface(
+            null, if (index == 3)
+                Typeface.BOLD else Typeface.NORMAL
+        )
     }
 
     private val onBackPressCallback = object : OnBackPressedCallback(true) {

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/home/HomeFragment.kt
@@ -23,9 +23,10 @@ import com.kakao.sdk.user.UserApiClient
 import android.graphics.Matrix
 import android.media.ExifInterface
 import com.pbl.grandmarket_android.R
-import com.pbl.grandmarket_android.aiimport.YoloDetector
+import com.pbl.grandmarket_android.ai.YoloDetector
 import com.pbl.grandmarket_android.data.model.UserRole
 import com.pbl.grandmarket_android.data.local.UserSession
+import com.pbl.grandmarket_android.data.repository.FoodRepository
 import com.pbl.grandmarket_android.ui.item_list.RegisterItemBottomSheet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -43,12 +44,11 @@ class HomeFragment : Fragment() {
     private var btnCameraRegister: View? = null
 
     private lateinit var yoloDetector: YoloDetector
+    private val foodRepository = FoodRepository() // AI 인식 후 점포 유무 확인에 사용
 
-    // 고해상도 사진을 위한 변수들
     private var photoUri: Uri? = null
     private var currentPhotoPath: String? = null
 
-    // 1. 카메라 권한 요청 런처
     private val requestPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
             if (isGranted) {
@@ -58,15 +58,12 @@ class HomeFragment : Fragment() {
             }
         }
 
-    // 2. 카메라 촬영 결과 처리 런처 (고해상도 파일 읽기)
     private val takePictureLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == android.app.Activity.RESULT_OK) {
                 currentPhotoPath?.let { path ->
-                    // 1. 이미지 읽기
                     var bitmap = BitmapFactory.decodeFile(path)
-                    
-                    // 2. 사진 회전 각도 확인 및 보정 (추가된 로직)
+
                     bitmap = rotateImageIfRequired(bitmap, path)
                     
                     bitmap?.let {
@@ -93,7 +90,7 @@ class HomeFragment : Fragment() {
         val matrix = Matrix()
         matrix.postRotate(degree)
         val rotatedImg = Bitmap.createBitmap(img, 0, 0, img.width, img.height, matrix, true)
-        if (rotatedImg != img) img.recycle() // 원본 비트맵 메모리 해제
+        if (rotatedImg != img) img.recycle()
         return rotatedImg
     }
 
@@ -169,8 +166,16 @@ class HomeFragment : Fragment() {
             withContext(Dispatchers.Main) {
                 if (results.isNotEmpty()) {
                     val topResult = results[0]
-                    // 사용자 요청대로 인식 결과만 토스트로 출력
                     Toast.makeText(requireContext(), "인식 결과: ${topResult.className}", Toast.LENGTH_SHORT).show()
+
+                    // 점포가 등록된 사용자만 식자재 등록 BottomSheet를 띄움
+                    foodRepository.checkStoreExists { isExists, message ->
+                        if (isExists) {
+                            showRegisterBottomSheet(topResult.className)
+                        } else {
+                            Toast.makeText(requireContext(), message ?: "점포를 먼저 등록해주세요.", Toast.LENGTH_SHORT).show()
+                        }
+                    }
                 } else {
                     Toast.makeText(requireContext(), "인식된 채소가 없습니다. 다시 찍어주세요.", Toast.LENGTH_SHORT).show()
                 }
@@ -178,8 +183,9 @@ class HomeFragment : Fragment() {
         }
     }
 
-    private fun showRegisterBottomSheet() {
-        val bottomSheet = RegisterItemBottomSheet()
+    private fun showRegisterBottomSheet(initialItemName: String? = null) {
+        // AI 인식 결과가 있으면 기본 검색어로 전달
+        val bottomSheet = RegisterItemBottomSheet.newInstance(initialItemName)
         bottomSheet.show(childFragmentManager, "RegisterItemBottomSheet")
     }
 

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/item_list/RegisterItemBottomSheet.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/item_list/RegisterItemBottomSheet.kt
@@ -22,6 +22,25 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
 
     private lateinit var api: ApiProductService
     private var currentWholesalePrice = 0L // 불러온 도매가 저장용
+    private var initialItemName: String? = null // AI 인식 결과로 전달된 기본 식자재명
+
+    companion object {
+        private const val ARG_ITEM_NAME = "arg_item_name"
+
+        // AI 인식 결과를 기본 검색어로 전달하기 위한 팩토리 메서드
+        fun newInstance(itemName: String?): RegisterItemBottomSheet {
+            val fragment = RegisterItemBottomSheet()
+            fragment.arguments = Bundle().apply {
+                putString(ARG_ITEM_NAME, itemName)
+            }
+            return fragment
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initialItemName = arguments?.getString(ARG_ITEM_NAME)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.bottom_sheet_item_add, container, false)
@@ -38,6 +57,12 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
         val btnMinusPrice = view.findViewById<Button>(R.id.btnMinusPrice)
         val btnPlusPrice = view.findViewById<Button>(R.id.btnPlusPrice)
         val btnRegisterComplete = view.findViewById<Button>(R.id.btnRegisterComplete)
+
+        // AI 인식 결과가 있으면 자동으로 검색어를 채워줌
+        initialItemName?.takeIf { it.isNotBlank() }?.let { itemName ->
+            etSearchItem.setText(itemName)
+            btnSearch.performClick()
+        }
 
         // API 세팅
         val retrofit = Retrofit.Builder()
@@ -95,7 +120,7 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
                 btnRegisterComplete.isEnabled = false
                 btnRegisterComplete.text = "등록 중..."
 
-                // Repository 호출 (콜백 함수 전달)
+                // Repository 호출
                 val repository = FoodRepository()
                 repository.foodAddWithValidation(name, sellPrice, currentWholesalePrice) { isSuccess, message ->
 
@@ -103,13 +128,11 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
                     btnRegisterComplete.isEnabled = true
                     btnRegisterComplete.text = "내 점포에 상품 등록하기"
 
-                    // 콜백 결과(진동벨)에 따른 처리
                     if (isSuccess) {
                         Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
-                        dismiss() // 팝업창 닫기
+                        dismiss()
                     } else {
                         Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show()
-                        // 실패 시에는 창을 닫지 않고 사용자가 다시 시도하거나 정보를 수정할 수 있게 둡니다.
                     }
                 }
             } else {

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/item_list/RegisterItemBottomSheet.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/item_list/RegisterItemBottomSheet.kt
@@ -15,6 +15,7 @@ import com.pbl.grandmarket_android.R
 import com.pbl.grandmarket_android.data.remote.ApiProductService
 import com.pbl.grandmarket_android.data.repository.FoodRepository
 import kotlinx.coroutines.launch
+import okhttp3.internal.userAgent
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
@@ -42,7 +43,11 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
         initialItemName = arguments?.getString(ARG_ITEM_NAME)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         return inflater.inflate(R.layout.bottom_sheet_item_add, container, false)
     }
 
@@ -75,8 +80,9 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
         btnSearch.setOnClickListener {
             val itemName = etSearchItem.text.toString()
 
-            val imm = requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            imm.hideSoftInputFromWindow(etSearchItem.windowToken,0)
+            val imm =
+                requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.hideSoftInputFromWindow(etSearchItem.windowToken, 0)
 
             if (itemName.isNotEmpty()) {
                 tvWholesalePriceInfo.text = "조회 중..."
@@ -85,7 +91,8 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
                         val response = api.getAveragePrice(itemName)
                         if (response.isSuccessful) {
                             currentWholesalePrice = response.body() ?: 0L
-                            tvWholesalePriceInfo.text = "오늘의 $itemName 도매가: ${currentWholesalePrice}원"
+                            tvWholesalePriceInfo.text =
+                                "오늘의 $itemName 도매가: ${currentWholesalePrice}원"
                             etSellPrice.setText(currentWholesalePrice.toString()) // 초기 가격 세팅
                         } else {
                             tvWholesalePriceInfo.text = "도매가 정보를 찾을 수 없습니다."
@@ -122,7 +129,11 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
 
                 // Repository 호출
                 val repository = FoodRepository()
-                repository.foodAddWithValidation(name, sellPrice, currentWholesalePrice) { isSuccess, message ->
+                repository.foodAddWithValidation(
+                    name,
+                    sellPrice,
+                    currentWholesalePrice
+                ) { isSuccess, message ->
 
                     // 결과가 돌아오면 UI 복구
                     btnRegisterComplete.isEnabled = true

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/MapBuyerFragment.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/MapBuyerFragment.kt
@@ -208,7 +208,7 @@ class MapBuyerFragment : Fragment() {
 
             val style = LabelStyles.from(
                 LabelStyle.from(R.drawable.store_marker)
-                    .setTextStyles(18, ContextCompat.getColor(requireContext(), R.color.black))
+                    .setTextStyles(21, ContextCompat.getColor(requireContext(), R.color.black))
             )
 
             val registeredStyle = labelManager.addLabelStyles(style)

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/MapBuyerFragment.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/MapBuyerFragment.kt
@@ -2,8 +2,11 @@ package com.pbl.grandmarket_android.ui.map
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.location.Location
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -23,6 +26,7 @@ import com.kakao.vectormap.LatLng
 import com.kakao.vectormap.MapLifeCycleCallback
 import com.kakao.vectormap.camera.CameraAnimation
 import com.kakao.vectormap.camera.CameraUpdateFactory
+import com.kakao.vectormap.label.Label
 import com.kakao.vectormap.label.LabelLayer
 import com.kakao.vectormap.label.LabelLayerOptions
 import com.kakao.vectormap.label.LabelOptions
@@ -31,7 +35,6 @@ import com.kakao.vectormap.label.LabelStyles
 import com.kakao.vectormap.label.LabelTextBuilder
 import com.pbl.grandmarket_android.util.KakaoMapSupport
 import com.pbl.grandmarket_android.R
-import com.pbl.grandmarket_android.ui.map.StoreListBottomSheetFragment
 import com.pbl.grandmarket_android.data.model.StoreItem
 import com.pbl.grandmarket_android.databinding.FragmentMapBuyerBinding
 
@@ -171,9 +174,11 @@ class MapBuyerFragment : Fragment() {
 
                     // 15km 이내만 필터링
                     if (distance <= SEARCH_RADIUS) {
-                        storeList.add(StoreItem(document.id, nickname, address, lat, lng, distance))
+                        // 마커 클릭 시 판매자 식자재 조회에 사용할 점포 정보를 마커 tag에 연결
+                        val storeItem = StoreItem(document.id, nickname, address, lat, lng, distance)
+                        storeList.add(storeItem)
 
-                        addStoreMarkerOnMap(storeLayer, lat, lng, nickname)
+                        addStoreMarkerOnMap(storeLayer, storeItem)
                     }
                 }
 
@@ -195,16 +200,40 @@ class MapBuyerFragment : Fragment() {
             }
     }
 
+    // 판매자 점포 마커 클릭 시 해당 판매자가 올린 식자재 바텀시트를 엽니다.
+    private fun setupStoreMarkerClickListener() {
+        kakaoMap?.setOnLabelClickListener { _, _, label: Label ->
+            val store = label.tag as? StoreItem ?: return@setOnLabelClickListener false
+            StoreFoodBottomSheetFragment(store) { clickedStore ->
+                openKakaoMapRoute(clickedStore)
+            }.show(parentFragmentManager, "StoreFoodBottomSheet")
+            true
+        }
+    }
+
+    // 카카오맵 앱 길찾기 열고, 앱이 없으면 웹 카카오맵 링크로 연결합니다.
+    private fun openKakaoMapRoute(store: StoreItem) {
+        val routeUri = Uri.parse(
+            "kakaomap://route?sp=$myLat,$myLng&ep=${store.latitude},${store.longitude}&by=CAR"
+        )
+        try {
+            startActivity(Intent(Intent.ACTION_VIEW, routeUri))
+        } catch (e: ActivityNotFoundException) {
+            val webUri = Uri.parse(
+                "https://map.kakao.com/link/to/${Uri.encode(store.storeName)},${store.latitude},${store.longitude}"
+            )
+            startActivity(Intent(Intent.ACTION_VIEW, webUri))
+        }
+    }
+
     private fun addStoreMarkerOnMap(
         layer: LabelLayer?,
-        lat: Double,
-        lng: Double,
-        storeName: String
+        store: StoreItem
     ) {
         try {
             val labelManager = kakaoMap?.labelManager ?: return
 
-            val labelText = LabelTextBuilder().setTexts(storeName)
+            val labelText = LabelTextBuilder().setTexts(store.storeName)
 
             val style = LabelStyles.from(
                 LabelStyle.from(R.drawable.store_marker)
@@ -213,11 +242,15 @@ class MapBuyerFragment : Fragment() {
 
             val registeredStyle = labelManager.addLabelStyles(style)
 
-            val options = LabelOptions.from(LatLng.from(lat, lng))
+            val options = LabelOptions.from(LatLng.from(store.latitude, store.longitude))
                 .setStyles(registeredStyle)
                 .setTexts(labelText)
 
-            layer?.addLabel(options)
+            // label 클릭 리스너에서 StoreItem을 꺼낼 수 있도록 tag와 clickable을 설정합니다.
+            layer?.addLabel(options)?.apply {
+                tag = store
+                isClickable = true
+            }
 
         } catch (e: Exception) {
             Log.e("MapBuyer", "마커 표시 에러", e)
@@ -241,6 +274,7 @@ class MapBuyerFragment : Fragment() {
             object : KakaoMapReadyCallback() {
                 override fun onMapReady(map: KakaoMap) {
                     kakaoMap = map
+                    setupStoreMarkerClickListener()
                     checkLocationPermission()
                 }
 

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/MapSellerFragment.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/MapSellerFragment.kt
@@ -28,7 +28,7 @@ import com.kakao.vectormap.MapLifeCycleCallback
 import com.kakao.vectormap.camera.CameraAnimation
 import com.kakao.vectormap.camera.CameraUpdateFactory
 import com.pbl.grandmarket_android.util.KakaoMapSupport
-import com.pbl.grandmarket_android.data.repository.StoreLocation
+import com.pbl.grandmarket_android.data.model.StoreLocation
 import com.pbl.grandmarket_android.databinding.FragmentMapSellerBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -244,6 +244,7 @@ class MapSellerFragment : Fragment() {
                         nickname = nickname,
                         latitude = lat,
                         longitude = lng,
+                        viewCount = 0,
                         address = address
                     )
 

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/StoreFoodBottomSheetFragment.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/StoreFoodBottomSheetFragment.kt
@@ -1,0 +1,112 @@
+package com.pbl.grandmarket_android.ui.map
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.Toast
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.button.MaterialButton
+import com.google.firebase.firestore.FirebaseFirestore
+import com.pbl.grandmarket_android.R
+import com.pbl.grandmarket_android.data.model.FoodEntity
+import com.pbl.grandmarket_android.data.model.StoreItem
+import com.pbl.grandmarket_android.ui.adapter.ProductCategory
+import com.pbl.grandmarket_android.ui.adapter.SaleItem
+import com.pbl.grandmarket_android.ui.adapter.SaleStatus
+import com.pbl.grandmarket_android.ui.adapter.SalesAdapter
+
+class StoreFoodBottomSheetFragment(
+    private val store: StoreItem,
+    private val onRouteClick: (StoreItem) -> Unit
+) : BottomSheetDialogFragment() {
+
+    private lateinit var adapter: SalesAdapter
+    private lateinit var emptyView: TextView
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_bottom_sheet_store_food, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.findViewById<TextView>(R.id.tv_store_food_title).text = "${store.storeName} 식자재"
+        view.findViewById<TextView>(R.id.tv_store_food_distance).text = store.getFormattedDistance()
+        emptyView = view.findViewById(R.id.tv_store_food_empty)
+
+        adapter = SalesAdapter(
+            onItemClick = {},
+            onDeleteClick = {},
+            onCompleteClick = {},
+            isEditable = false
+        )
+
+        view.findViewById<RecyclerView>(R.id.recycler_view_store_foods).apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = this@StoreFoodBottomSheetFragment.adapter
+        }
+
+        view.findViewById<MaterialButton>(R.id.btn_route_store).setOnClickListener {
+            onRouteClick(store)
+        }
+
+        loadStoreFoods()
+    }
+
+    // storeLocation 문서 id와 닉네임을 foodList의 kakaoId/sellerName과 매칭해 해당 판매자 식자재만 조회
+    private fun loadStoreFoods() {
+        FirebaseFirestore.getInstance()
+            .collection("foodList")
+            .whereEqualTo("kakaoId", store.storeId)
+            .get()
+            .addOnSuccessListener { snapshot ->
+                val items = snapshot.documents.mapNotNull { document ->
+                    val food = document.toObject(FoodEntity::class.java) ?: return@mapNotNull null
+                    if (food.sellerName != store.storeName) return@mapNotNull null
+                    SaleItem(
+                        id = document.id,
+                        title = food.foodName,
+                        price = food.price.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt(),
+                        category = food.category.toProductCategory(),
+                        imageUrl = null,
+                        stockCount = 0,
+                        status = food.status.toSaleStatus(),
+                        createdAt = food.timestamp
+                    )
+                }.sortedByDescending { it.createdAt }
+
+                adapter.submitList(items)
+                emptyView.visibility = if (items.isEmpty()) View.VISIBLE else View.GONE
+            }
+            .addOnFailureListener { error ->
+                Log.e("StoreFoodBottomSheet", "판매자 식자재 조회 실패", error)
+                Toast.makeText(requireContext(), "식자재 목록을 불러오지 못했습니다.", Toast.LENGTH_SHORT).show()
+                emptyView.visibility = View.VISIBLE
+            }
+    }
+
+    // Firebase 문자열 카테고리를 기존 리스트 UI 카테고리 타입으로 변환
+    private fun String.toProductCategory(): ProductCategory {
+        return when (this) {
+            "육류", "MEAT", "meat" -> ProductCategory.MEAT
+            else -> ProductCategory.VEGETABLE
+        }
+    }
+
+    // Firebase 판매 상태 문자열을 기존 리스트 UI 상태 타입으로 변환
+    private fun String.toSaleStatus(): SaleStatus {
+        return when (this) {
+            "판매완료", "SOLD_OUT", "sold_out" -> SaleStatus.SOLD_OUT
+            else -> SaleStatus.ON_SALE
+        }
+    }
+}

--- a/android/app/src/main/res/layout/fragment_bottom_sheet_store_food.xml
+++ b/android/app/src/main/res/layout/fragment_bottom_sheet_store_food.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_bottom_sheet_surface"
+    android:orientation="vertical"
+    android:paddingTop="8dp">
+
+    <View
+        android:layout_width="40dp"
+        android:layout_height="4dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="16dp"
+        android:background="#D9D9D9" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="20dp"
+        android:paddingBottom="12dp">
+
+        <TextView
+            android:id="@+id/tv_store_food_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="@color/black"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            tools:text="판매자 식자재" />
+
+        <TextView
+            android:id="@+id/tv_store_food_distance"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/orange_main"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            tools:text="1.2km" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/tv_store_food_empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="28dp"
+        android:text="등록된 식자재가 없습니다."
+        android:textAlignment="center"
+        android:textColor="#888888"
+        android:textSize="14sp"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view_store_foods"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:paddingBottom="8dp"
+        tools:listitem="@layout/item_sale" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_route_store"
+        android:layout_width="match_parent"
+        android:layout_height="54dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="24dp"
+        android:text="판매자 점포까지 길찾기"
+        android:textAllCaps="false"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:backgroundTint="@color/orange_main"
+        app:cornerRadius="12dp" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -198,7 +198,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="4dp"
-                            android:text="사진을 찍어 식자재를 빠르게 등록"
+                            android:text="AI 이미지 인식으로 식자재를 빠르게 등록"
                             android:textColor="#BBBBA8"
                             android:textSize="12sp" />
 


### PR DESCRIPTION
# PR-26 성공적으로 객체 탐지(이미지 인식) 이후 식자재 등록 유도 기능

> PR 제목: `PR-26 성공적으로 객체 탐지(이미지 인식) 이후 식자재 등록 유도 기능`
> 
> 브랜치명: `woneyH-feat-12`
---

## 🔒 Close Issue (필수)
- GitHub: Closes #45   #47
---


## 🔍 변경 유형

- [x] ✨ 새 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [x] ♻️ 리팩터링 (refactor)
- [ ] 🎨 스타일 / UI 개선
- [ ] 📦 의존성 업데이트
- [ ] 🔧 설정 / 빌드 변경
- [ ] 📝 문서 업데이트
- [ ] 🚀 배포 관련
- [ ] ⚡ 성능 개선
- [ ] 🔒 보안 수정
- [x]  🤖 인지모델, ai 관련 개선
---

## 💡 작업 내용

### 무엇을 변경했나요?
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- 팀원이 변경해 준 인지모델로 적용
- 이미지 인식을 성공하면 식자재 등록 유도
- 인식된 식자재 이름 기반으로 편리하게 등록하게끔 구현
- 맵 탭에서 마커클릭 시 점포에 등록된 식자재들 리스트 디스플레이
- 현재 위치에서 판매자 점포까지의 길찾기 기능 도입
- 길찾기 기능 카카오맵에 의존시킴
---


## ✅ 테스트

- [ ] 유닛 테스트 추가 / 수정
- [ ] 통합 테스트 확인
- [x] 로컬에서 직접 검증

<!-- 테스트 방법이나 시나리오를 설명해주세요 -->
- api 35 기기 테스트
---

## 📸 스크린샷(선택)

<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요 -->

| Before | After |
|--------|-------|
|        |       |

---

## ✔️ 셀프 체크리스트

- [x] 코드 스타일 가이드를 따랐다
- [x] 불필요한 주석 / console.log를 제거했다
- [x] 하드코딩된 값이 없다
- [x] 민감 정보(API 키, 비밀번호 등)가 포함되지 않았다
- [x] PR 제목이 컨벤션에 맞게 작성되었다
