### PR TITLE
PR-32:  Firebase Storage 사용  판매 식자재 이미지 등록 기능 추가함

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:34.12.0"))
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-firestore-ktx:25.1.4")
+    implementation("com.google.firebase:firebase-storage")
 
     //Google Location 의존성 추가
     implementation("com.google.android.gms:play-services-location:21.2.0")

--- a/android/app/src/main/java/com/pbl/grandmarket_android/data/model/FoodEntity.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/data/model/FoodEntity.kt
@@ -8,5 +8,6 @@ data class FoodEntity (
     val marketPrice: Long = 0L, //해당 식자재 평균 시세
     val category: String = "",  //식자재 카테고리
     val status: String = "판매중", //판매 상황
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long = System.currentTimeMillis(),
+    val imageUrl: String = "" // Firebase Storage에 업로드된 상품 이미지 URL
 )

--- a/android/app/src/main/java/com/pbl/grandmarket_android/data/repository/FoodRepository.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/data/repository/FoodRepository.kt
@@ -1,11 +1,17 @@
 package com.pbl.grandmarket_android.data.repository
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.location.Location
+import android.net.Uri
 import android.util.Log
+import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
 import com.kakao.sdk.user.UserApiClient
 import com.pbl.grandmarket_android.data.model.FoodEntity
+import java.io.ByteArrayOutputStream
 
 data class SellerFoodItem(
     val id: String,
@@ -14,7 +20,8 @@ data class SellerFoodItem(
     val category: String,
     val status: String,
     val timestamp: Long,
-    val sellerName: String
+    val sellerName: String,
+    val imageUrl: String = ""
 )
 
 class FoodRepository {
@@ -48,6 +55,7 @@ class FoodRepository {
         foodName: String,
         price: Long,
         marketPrice: Long,
+        imageUri: Uri? = null,
         onResult: (isSuccess: Boolean, message: String?) -> Unit
     ) {
         UserApiClient.instance.me { user, error ->
@@ -62,7 +70,11 @@ class FoodRepository {
             db.collection("storeLocation").document(kakaoId).get()
                 .addOnSuccessListener { document ->
                     if (document.exists()) {
-                        saveFoodToFirebase(kakaoId, nickname, foodName, price, marketPrice, onResult)
+                        if (imageUri != null) {
+                            uploadImageThenSave(kakaoId, nickname, foodName, price, marketPrice, imageUri, onResult)
+                        } else {
+                            saveFoodToFirebase(kakaoId, nickname, foodName, price, marketPrice, "", onResult)
+                        }
                     } else {
                         // TODO: "점포를 먼저 등록해주세요" 팝업이나 알림 띄우기
                         onResult(false, "점포를 먼저 등록해주세요")
@@ -75,12 +87,99 @@ class FoodRepository {
         }
     }
 
+    private fun uploadImageThenSave(
+        kakaoId: String,
+        sellerName: String,
+        foodName: String,
+        price: Long,
+        marketPrice: Long,
+        imageUri: Uri,
+        onResult: (Boolean, String?) -> Unit
+    ) {
+        val compressedBytes = compressImage(imageUri)
+        if (compressedBytes == null) {
+            onResult(false, "이미지 처리에 실패했습니다")
+            return
+        }
+        Log.d("FoodRepository", "압축 후 이미지 크기: ${compressedBytes.size / 1024} KB")
+
+        val storageRef = FirebaseStorage.getInstance().reference
+            .child("food_images/$kakaoId/${System.currentTimeMillis()}.jpg")
+
+        storageRef.putBytes(compressedBytes)
+            .addOnSuccessListener {
+                storageRef.downloadUrl
+                    .addOnSuccessListener { downloadUrl ->
+                        Log.d("FoodRepository", "이미지 업로드 성공: $downloadUrl")
+                        saveFoodToFirebase(kakaoId, sellerName, foodName, price, marketPrice, downloadUrl.toString(), onResult)
+                    }
+                    .addOnFailureListener { e ->
+                        Log.e("FoodRepository", "다운로드 URL 가져오기 실패", e)
+                        onResult(false, "이미지 URL 가져오기 실패: ${e.message}")
+                    }
+            }
+            .addOnFailureListener { e ->
+                Log.e("FoodRepository", "이미지 업로드 실패: ${e.message}", e)
+                onResult(false, "이미지 업로드 실패: ${e.message}")
+            }
+    }
+    private fun compressImage(imageUri: Uri): ByteArray? {
+        val context = FirebaseApp.getInstance().applicationContext
+        return try {
+            // 1차 디코딩: 실제 픽셀을 읽지 않고 원본 크기만 측정
+            val sizeOptions = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            context.contentResolver.openInputStream(imageUri)?.use {
+                BitmapFactory.decodeStream(it, null, sizeOptions)
+            }
+
+            // 1024px 이내로 줄일 inSampleSize 계산 (2의 거듭제곱)
+            val maxPx = 1024
+            val decodeOptions = BitmapFactory.Options().apply {
+                inSampleSize = calcInSampleSize(sizeOptions.outWidth, sizeOptions.outHeight, maxPx)
+            }
+
+            // 2차 디코딩: inSampleSize를 적용해 메모리 절약하며 디코딩
+            val decoded = context.contentResolver.openInputStream(imageUri)?.use {
+                BitmapFactory.decodeStream(it, null, decodeOptions)
+            } ?: return null
+
+            // inSampleSize는 2의 거듭제곱이라 maxPx를 약간 초과할 수 있어 최종 스케일 조정
+            val scaled = if (decoded.width > maxPx || decoded.height > maxPx) {
+                val ratio = minOf(maxPx.toFloat() / decoded.width, maxPx.toFloat() / decoded.height)
+                Bitmap.createScaledBitmap(
+                    decoded,
+                    (decoded.width * ratio).toInt(),
+                    (decoded.height * ratio).toInt(),
+                    true
+                ).also { if (it !== decoded) decoded.recycle() }
+            } else decoded
+
+            ByteArrayOutputStream().use { out ->
+                scaled.compress(Bitmap.CompressFormat.JPEG, 75, out)
+                scaled.recycle()
+                out.toByteArray()
+            }
+        } catch (e: Exception) {
+            Log.e("FoodRepository", "이미지 압축 실패", e)
+            null
+        }
+    }
+
+    private fun calcInSampleSize(width: Int, height: Int, maxPx: Int): Int {
+        var sample = 1
+        while ((width / sample) > maxPx || (height / sample) > maxPx) {
+            sample *= 2
+        }
+        return sample
+    }
+
     private fun saveFoodToFirebase(
         kakaoId: String,
         sellerName: String,
         foodName: String,
         price: Long,
         marketPrice: Long,
+        imageUrl: String,
         onResult: (Boolean, String?) -> Unit
     ) {
         val foodData = FoodEntity(
@@ -88,7 +187,8 @@ class FoodRepository {
             sellerName = sellerName,
             foodName = foodName,
             price = price,
-            marketPrice = marketPrice
+            marketPrice = marketPrice,
+            imageUrl = imageUrl
         )
 
         db.collection("foodList").add(foodData)
@@ -125,7 +225,8 @@ class FoodRepository {
                             category = food.category,
                             status = food.status,
                             timestamp = food.timestamp,
-                            sellerName = food.sellerName
+                            sellerName = food.sellerName,
+                            imageUrl = food.imageUrl
                         )
                     }.sortedByDescending { it.timestamp }
                     onResult(true, items, null)
@@ -257,7 +358,8 @@ class FoodRepository {
                                 category = food.category,
                                 status = food.status,
                                 timestamp = food.timestamp,
-                                sellerName = food.sellerName
+                                sellerName = food.sellerName,
+                                imageUrl = food.imageUrl
                             )
                         }.sortedByDescending { it.timestamp }
 

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/adapter/SalesAdapter.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/adapter/SalesAdapter.kt
@@ -8,6 +8,8 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.pbl.grandmarket_android.R
 import com.pbl.grandmarket_android.databinding.ItemSaleBinding
 
 // 데이터 클래스
@@ -84,11 +86,15 @@ class SalesAdapter(
             binding.tvStatus.text = statusText
             binding.tvStatus.setTextColor(Color.parseColor(statusTextColor))
 
-            // TODO: Glide / Coil 이미지 로드
-            // Glide.with(binding.root)
-            //     .load(item.imageUrl)
-            //     .placeholder(R.drawable.ic_image_placeholder)
-            //     .into(binding.ivProductImage)
+            if (!item.imageUrl.isNullOrBlank()) {
+                binding.ivProductImage.load(item.imageUrl) {
+                    crossfade(true)
+                    placeholder(R.drawable.item_list_image_placeholder)
+                    error(R.drawable.item_list_image_placeholder)
+                }
+            } else {
+                binding.ivProductImage.setImageResource(R.drawable.item_list_image_placeholder)
+            }
 
             if (!isEditable && item.sellerName.isNotBlank()) {
                 binding.tvSellerName.visibility = View.VISIBLE

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/home/HomeFragment.kt
@@ -198,7 +198,7 @@ class HomeFragment : Fragment() {
                     // 점포가 등록된 사용자만 식자재 등록 BottomSheet를 띄움
                     foodRepository.checkStoreExists { isExists, message ->
                         if (isExists) {
-                            showRegisterBottomSheet(topResult.className)
+                            showRegisterBottomSheet(topResult.className, photoUri)
                         } else {
                             Toast.makeText(requireContext(), message ?: "점포를 먼저 등록해주세요.", Toast.LENGTH_SHORT).show()
                         }
@@ -210,9 +210,8 @@ class HomeFragment : Fragment() {
         }
     }
 
-    private fun showRegisterBottomSheet(initialItemName: String? = null) {
-        // AI 인식 결과가 있으면 기본 검색어로 전달
-        val bottomSheet = RegisterItemBottomSheet.newInstance(initialItemName)
+    private fun showRegisterBottomSheet(initialItemName: String? = null, capturedPhotoUri: Uri? = null) {
+        val bottomSheet = RegisterItemBottomSheet.newInstance(initialItemName, capturedPhotoUri?.toString())
         bottomSheet.show(childFragmentManager, "RegisterItemBottomSheet")
     }
 

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/item_list/RegisterItemBottomSheet.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/item_list/RegisterItemBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.pbl.grandmarket_android.ui.item_list
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -7,24 +8,30 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.EditText
+import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
+import coil.load
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.pbl.grandmarket_android.R
 import com.pbl.grandmarket_android.data.remote.ApiProductService
 import com.pbl.grandmarket_android.data.repository.FoodRepository
 import kotlinx.coroutines.launch
-import okhttp3.internal.userAgent
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 class RegisterItemBottomSheet : BottomSheetDialogFragment() {
 
     private lateinit var api: ApiProductService
-    private var currentWholesalePrice = 0L // 불러온 도매가 저장용
-    private var initialItemName: String? = null // AI 인식 결과로 전달된 기본 식자재명
+    private var currentWholesalePrice = 0L
+    private var initialItemName: String? = null
     private var onRegisteredListener: (() -> Unit)? = null
+
+    private var selectedImageUri: Uri? = null
 
     fun setOnRegisteredListener(listener: () -> Unit): RegisterItemBottomSheet {
         onRegisteredListener = listener
@@ -33,20 +40,35 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
 
     companion object {
         private const val ARG_ITEM_NAME = "arg_item_name"
+        private const val ARG_PHOTO_URI = "arg_photo_uri"
 
-        // AI 인식 결과를 기본 검색어로 전달하기 위한 팩토리 메서드
-        fun newInstance(itemName: String?): RegisterItemBottomSheet {
+        fun newInstance(itemName: String?, photoUri: String? = null): RegisterItemBottomSheet {
             val fragment = RegisterItemBottomSheet()
             fragment.arguments = Bundle().apply {
                 putString(ARG_ITEM_NAME, itemName)
+                putString(ARG_PHOTO_URI, photoUri)
             }
             return fragment
         }
     }
 
+    private val pickImageLauncher =
+        registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            uri?.let {
+                selectedImageUri = it
+                updateImagePreview(it)
+            }
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initialItemName = arguments?.getString(ARG_ITEM_NAME)
+
+        arguments?.getString(ARG_PHOTO_URI)?.let { uriString ->
+            if (uriString.isNotBlank()) {
+                selectedImageUri = Uri.parse(uriString)
+            }
+        }
     }
 
     override fun onCreateView(
@@ -60,14 +82,25 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // 뷰
-        val etSearchItem = view.findViewById<EditText>(R.id.etSearchItem)
-        val btnSearch = view.findViewById<Button>(R.id.btnSearch)
+        val etSearchItem         = view.findViewById<EditText>(R.id.etSearchItem)
+        val btnSearch            = view.findViewById<Button>(R.id.btnSearch)
         val tvWholesalePriceInfo = view.findViewById<TextView>(R.id.tvWholesalePriceInfo)
-        val etSellPrice = view.findViewById<EditText>(R.id.etSellPrice)
-        val btnMinusPrice = view.findViewById<Button>(R.id.btnMinusPrice)
-        val btnPlusPrice = view.findViewById<Button>(R.id.btnPlusPrice)
-        val btnRegisterComplete = view.findViewById<Button>(R.id.btnRegisterComplete)
+        val etSellPrice          = view.findViewById<EditText>(R.id.etSellPrice)
+        val btnMinusPrice        = view.findViewById<Button>(R.id.btnMinusPrice)
+        val btnPlusPrice         = view.findViewById<Button>(R.id.btnPlusPrice)
+        val btnRegisterComplete  = view.findViewById<Button>(R.id.btnRegisterComplete)
+
+        val ivImagePreview         = view.findViewById<ImageView>(R.id.ivImagePreview)
+        val layoutImagePlaceholder = view.findViewById<LinearLayout>(R.id.layoutImagePlaceholder)
+        val btnPickImage           = view.findViewById<Button>(R.id.btnPickImage)
+
+        selectedImageUri?.let { updateImagePreview(it, ivImagePreview, layoutImagePlaceholder, btnPickImage) }
+
+        btnPickImage.setOnClickListener {
+            pickImageLauncher.launch(
+                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+            )
+        }
 
         // AI 인식 결과가 있으면 자동으로 검색어를 채워줌
         initialItemName?.takeIf { it.isNotBlank() }?.let { itemName ->
@@ -85,9 +118,7 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
         // 도매가 검색 버튼 클릭
         btnSearch.setOnClickListener {
             val itemName = etSearchItem.text.toString()
-
-            val imm =
-                requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            val imm = requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as InputMethodManager
             imm.hideSoftInputFromWindow(etSearchItem.windowToken, 0)
 
             if (itemName.isNotEmpty()) {
@@ -97,9 +128,8 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
                         val response = api.getAveragePrice(itemName)
                         if (response.isSuccessful) {
                             currentWholesalePrice = response.body() ?: 0L
-                            tvWholesalePriceInfo.text =
-                                "오늘의 $itemName 도매가: ${currentWholesalePrice}원"
-                            etSellPrice.setText(currentWholesalePrice.toString()) // 초기 가격 세팅
+                            tvWholesalePriceInfo.text = "오늘의 $itemName 도매가: ${currentWholesalePrice}원"
+                            etSellPrice.setText(currentWholesalePrice.toString())
                         } else {
                             tvWholesalePriceInfo.text = "도매가 정보를 찾을 수 없습니다."
                         }
@@ -129,25 +159,22 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
             val sellPrice = etSellPrice.text.toString().toLongOrNull() ?: 0L
 
             if (name.isNotEmpty() && sellPrice > 0) {
-                // 중복 클릭 방지
                 btnRegisterComplete.isEnabled = false
                 btnRegisterComplete.text = "등록 중..."
 
-                // Repository 호출
                 val repository = FoodRepository()
                 repository.foodAddWithValidation(
                     name,
                     sellPrice,
-                    currentWholesalePrice
+                    currentWholesalePrice,
+                    selectedImageUri
                 ) { isSuccess, message ->
 
-                    // 결과가 돌아오면 UI 복구
                     btnRegisterComplete.isEnabled = true
                     btnRegisterComplete.text = "내 점포에 상품 등록하기"
 
                     if (isSuccess) {
                         Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
-                        // 등록 성공 시 콜백 실행 후 닫기 → SellListFragment가 목록을 즉시 갱신
                         onRegisteredListener?.invoke()
                         dismiss()
                     } else {
@@ -158,5 +185,27 @@ class RegisterItemBottomSheet : BottomSheetDialogFragment() {
                 Toast.makeText(requireContext(), "상품명과 가격을 정확히 입력해주세요.", Toast.LENGTH_SHORT).show()
             }
         }
+    }
+
+    private fun updateImagePreview(uri: Uri) {
+        val view = view ?: return
+        val ivImagePreview         = view.findViewById<ImageView>(R.id.ivImagePreview)
+        val layoutImagePlaceholder = view.findViewById<LinearLayout>(R.id.layoutImagePlaceholder)
+        val btnPickImage           = view.findViewById<Button>(R.id.btnPickImage)
+        updateImagePreview(uri, ivImagePreview, layoutImagePlaceholder, btnPickImage)
+    }
+
+    private fun updateImagePreview(
+        uri: Uri,
+        ivPreview: ImageView,
+        placeholder: LinearLayout,
+        btnPick: Button
+    ) {
+        placeholder.visibility = View.GONE
+        ivPreview.visibility = View.VISIBLE
+        ivPreview.load(uri) {
+            crossfade(true)
+        }
+        btnPick.text = "이미지 변경"
     }
 }

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/MapBuyerFragment.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/MapBuyerFragment.kt
@@ -106,7 +106,9 @@ class MapBuyerFragment : Fragment() {
                 Toast.makeText(requireContext(), "주변 반경 15km 내에 점포가 없습니다.", Toast.LENGTH_SHORT)
                     .show()
             } else {
-                val bottomSheet = StoreListBottomSheetFragment(storeList)
+                val bottomSheet = StoreListBottomSheetFragment(storeList) { clickedStore ->
+                    showStoreFoodBottomSheet(clickedStore)
+                }
                 bottomSheet.show(parentFragmentManager, "StoreListBottomSheet")
             }
         }
@@ -203,11 +205,14 @@ class MapBuyerFragment : Fragment() {
     private fun setupStoreMarkerClickListener() {
         kakaoMap?.setOnLabelClickListener { _, _, label: Label ->
             val store = label.tag as? StoreItem ?: return@setOnLabelClickListener false
-            StoreFoodBottomSheetFragment(store) { clickedStore ->
-                openKakaoMapRoute(clickedStore)
-            }.show(parentFragmentManager, "StoreFoodBottomSheet")
+            showStoreFoodBottomSheet(store)
             true
         }
+    }
+    private fun showStoreFoodBottomSheet(store: StoreItem) {
+        StoreFoodBottomSheetFragment(store) { clickedStore ->
+            openKakaoMapRoute(clickedStore)
+        }.show(parentFragmentManager, "StoreFoodBottomSheet")
     }
 
     // 카카오맵 앱 길찾기 열고, 앱이 없으면 웹 카카오맵 링크로 연결

--- a/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/StoreListBottomSheetFragment.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/ui/map/StoreListBottomSheetFragment.kt
@@ -12,7 +12,8 @@ import com.pbl.grandmarket_android.data.model.StoreItem
 import com.pbl.grandmarket_android.ui.adapter.StoreListAdapter
 
 class StoreListBottomSheetFragment(
-    private val sortedStores: List<StoreItem>
+    private val sortedStores: List<StoreItem>,
+    private val onStoreClick: (StoreItem) -> Unit = {}
 ) : BottomSheetDialogFragment() {
 
     override fun onCreateView(
@@ -26,6 +27,7 @@ class StoreListBottomSheetFragment(
 
         val adapter = StoreListAdapter(sortedStores) { clickedStore ->
             dismiss()
+            onStoreClick(clickedStore)
         }
         recyclerView.adapter = adapter
 

--- a/android/app/src/main/java/com/pbl/grandmarket_android/view_model/SalesListViewModel.kt
+++ b/android/app/src/main/java/com/pbl/grandmarket_android/view_model/SalesListViewModel.kt
@@ -130,7 +130,7 @@ class SalesListViewModel : ViewModel() {
             title = item.foodName,
             price = item.price.toInt(),
             category = item.category.toProductCategory(),
-            imageUrl = null,
+            imageUrl = item.imageUrl.ifBlank { null },
             stockCount = 0,
             status = item.status.toSaleStatus(),
             createdAt = item.timestamp,

--- a/android/app/src/main/res/layout/bottom_sheet_item_add.xml
+++ b/android/app/src/main/res/layout/bottom_sheet_item_add.xml
@@ -37,6 +37,60 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/ivImagePreview"
+            android:layout_width="match_parent"
+            android:layout_height="150dp"
+            android:scaleType="centerCrop"
+            android:background="#F5F0DC"
+            android:contentDescription="상품 이미지 미리보기"
+            android:visibility="gone" />
+
+        <LinearLayout
+            android:id="@+id/layoutImagePlaceholder"
+            android:layout_width="match_parent"
+            android:layout_height="100dp"
+            android:background="@drawable/home_search_bar"
+            android:backgroundTint="#F5F0DC"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="🖼"
+                android:textSize="28sp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="상품 이미지를 등록해보세요"
+                android:textColor="#BBBBA8"
+                android:textSize="11sp" />
+
+        </LinearLayout>
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btnPickImage"
+            android:layout_width="match_parent"
+            android:layout_height="46dp"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/home_search_bar"
+            android:backgroundTint="#F5EFE0"
+            android:text="갤러리에서 이미지 선택"
+            android:textColor="#E8821A"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
         android:orientation="horizontal">
 
         <EditText


### PR DESCRIPTION
# PR-32: 판매 식자재 이미지 등록 기능 추가함

> PR 제목: `PR-32: 판매 식자재 이미지 등록 기능 추가함`
> 
> 브랜치명: `woneyH-feat-14`

---

## 🔒 Close Issue (필수)
- GitHub: Closes #58 
---


## 🔍 변경 유형

- [x] ✨ 새 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] ♻️ 리팩터링 (refactor)
- [ ] 🎨 스타일 / UI 개선
- [x] 📦 의존성 업데이트
- [ ] 🔧 설정 / 빌드 변경
- [ ] 📝 문서 업데이트
- [ ] 🚀 배포 관련
- [ ] ⚡ 성능 개선
- [ ] 🔒 보안 수정

---

## 💡 작업 내용

### 무엇을 변경했나요?
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- 이미지 인식으로 등록할 경우 찍은 사진으로 Storage에 저장됨.
- 검색을 통한 식자재 등록에서 사용자가 식자재 이미지를 업로드해서 등록 가능.
- Firebase Storage를 통해 food_images 관리한다.
- 등록된 식자재 이미지를 불러올 땐 이미지 URL로 가져온다.

### 구현한 이유
<!-- 기술적 결정의 이유, 대안 검토 내용 등 -->
- Firebase Storage 사용.


---


## ✅ 테스트

- [ ] 유닛 테스트 추가 / 수정
- [ ] 통합 테스트 확인
- [x] 로컬에서 직접 검증

<!-- 테스트 방법이나 시나리오를 설명해주세요 -->
- api 35 기기 테스트 


---

## 📸 스크린샷(선택)

<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요 -->

| Before | After |
|--------|-------|
|        |       |

---

## ⚠️ 리뷰가이드 (필수)

<!-- 리뷰어가 특히 집중해서 봐야 할 부분, 배포 전 주의사항 등 하단은 예시입니다. -->

- [ ] DB 마이그레이션 필요
- [ ] 환경 변수 추가 필요
- [ ] 관련 팀 공유 필요

---

## ✔️ 셀프 체크리스트

- [x] 코드 스타일 가이드를 따랐다
- [x] 불필요한 주석 / console.log를 제거했다
- [x] 하드코딩된 값이 없다
- [x] 민감 정보(API 키, 비밀번호 등)가 포함되지 않았다
- [x] PR 제목이 컨벤션에 맞게 작성되었다
